### PR TITLE
added ability to publish a gl::Texture for current FBO support

### DIFF
--- a/src/syphonServer.h
+++ b/src/syphonServer.h
@@ -40,6 +40,7 @@ class syphonServer {
 	std::string getName();
 	void publishScreen();
     void publishTexture(ci::gl::TextureRef inputTexture);
+    void publishTexture(ci::gl::Texture &inputTexture);
 	
     
 protected:

--- a/src/syphonServer.mm
+++ b/src/syphonServer.mm
@@ -109,3 +109,20 @@ void syphonServer::publishTexture(ci::gl::TextureRef inputTexture)
 	}
 }
 
+
+void syphonServer::publishTexture(ci::gl::Texture &inputTexture)
+{
+	if(inputTexture){
+		NSAutoreleasePool* pool = [[NSAutoreleasePool alloc] init];
+		GLuint texID = inputTexture.getId();
+		if (!mSyphon)
+		{
+			mSyphon = [[SyphonServer alloc] initWithName:@"Untitled" context:CGLGetCurrentContext() options:nil];
+		}
+		[(SyphonServer *)mSyphon publishFrameTexture:texID textureTarget:GL_TEXTURE_2D imageRegion:NSMakeRect(0, 0, inputTexture.getWidth(), inputTexture.getHeight()) textureDimensions:NSMakeSize(inputTexture.getWidth(), inputTexture.getHeight()) flipped:true];
+		[pool drain];
+	} else {
+		ci::app::console()<<"syphonServer is not setup, or texture is not properly backed.  Cannot draw.\n";
+	}
+}
+


### PR DESCRIPTION
Overloading `publishTexture` so that one can do:

```
mSyphon.publishTexture( mFbo.getTexture() );
```

Not my idea, but I need it for a project; see https://forum.libcinder.org/topic/an-easier-cinder-syphon for discussion.
